### PR TITLE
Fix digital-objects development path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,6 @@ WORKDIR /app
 COPY . .
 
 EXPOSE 4000
-ENTRYPOINT ["jekyll", "s", "-H", "0.0.0.0"]
+
+ENTRYPOINT ["jekyll"]
+CMD ["s", "-H", "0.0.0.0"]

--- a/_config.production.yml
+++ b/_config.production.yml
@@ -9,7 +9,7 @@ url: https://www.lib.uidaho.edu
 baseurl: /demo/moscon
 
 # url to objects folder
-digital-objects: https://de-collectionbuilder-001.nyc3.cdn.digitaloceanspaces.com
+digital-objects: https://lchs.sfo2.cdn.digitaloceanspaces.com
 
 # location of code
 source-code: https://github.com/CollectionBuilder
@@ -50,7 +50,7 @@ google-analytics-id:
 # add liquid profiler to id bottlenecks
 # profile: true
 
-exclude: [docs/, Rakefile, README.md, LICENSE, Dockerfile, docker-compose.yml, docker-compose.production.yml]
+exclude: [docs/, Rakefile, README.md, LICENSE, objects/, scripts/, Dockerfile, docker-compose*.yml]
 
 # compress CSS output
 sass:

--- a/_config.production_preview.yml
+++ b/_config.production_preview.yml
@@ -9,7 +9,7 @@ url: http://0.0.0.0:4000
 baseurl: /demo/moscon
 
 # url to objects folder
-digital-objects: https://de-collectionbuilder-001.nyc3.cdn.digitaloceanspaces.com
+digital-objects: https://lchs.sfo2.cdn.digitaloceanspaces.com
 
 # location of code
 source-code: https://github.com/CollectionBuilder
@@ -50,7 +50,7 @@ google-analytics-id:
 # add liquid profiler to id bottlenecks
 # profile: true
 
-exclude: [docs/, Rakefile, README.md, LICENSE, Dockerfile, docker-compose.yml, docker-compose.production.yml]
+exclude: [docs/, Rakefile, README.md, LICENSE, objects/, scripts/, Dockerfile, docker-compose*.yml]
 
 # compress CSS output
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: http://0.0.0.0:4000
 baseurl: /demo/moscon
 
 # url to objects folder
-digital-objects: objects
+digital-objects: /demo/moscon/objects
 
 # location of code
 source-code: https://github.com/CollectionBuilder
@@ -50,7 +50,7 @@ google-analytics-id:
 # add liquid profiler to id bottlenecks
 # profile: true
 
-exclude: [docs/, Rakefile, README.md, LICENSE, Dockerfile, docker-compose.yml, docker-compose.production.yml]
+exclude: [docs/, Rakefile, README.md, LICENSE, objects/, scripts/, Dockerfile, docker-compose*.yml]
 
 # compress CSS output
 sass:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -7,4 +7,4 @@ services:
       service: collectionbuilder
     environment:
       JEKYLL_ENV: production
-    command: --config=_config.production.yml
+    command: ["build", "--config=_config.production.yml"]

--- a/docker-compose.production_preview.yml
+++ b/docker-compose.production_preview.yml
@@ -7,4 +7,4 @@ services:
       service: collectionbuilder
     environment:
       JEKYLL_ENV: production
-    command: --config=_config.production_preview.yml
+    command: ["s", "-H", "0.0.0.0", "--config=_config.production_preview.yml"]


### PR DESCRIPTION
This PR:
- fixes the digital-objects development path
- makes jekyll the Docker `ENTRYPOINT` for easy overriding of the `CMD` for production builds
- modifies `_config.production.yml` to `build` instead of `serve`