### PR TITLE
Use multi-file --config=<file>,<file> approach to simply the _config*.yml files

### DIFF
--- a/_config.production.yml
+++ b/_config.production.yml
@@ -1,57 +1,8 @@
-# CollectionBuilder
-# Jekyll Digital Collection Generator
 
-# URL variables
 # site domain
 url: https://www.lib.uidaho.edu
-# location on the domain
-# e.g. /digital/hjccc
-baseurl: /demo/moscon
 
-# url to objects folder
+# url to production objects store
 digital-objects: https://lchs.sfo2.cdn.digitaloceanspaces.com
 
-# location of code
-source-code: https://github.com/CollectionBuilder
-
-# Site settings
-title: Collection Builder CDM Skin
-# header and head metadata
-tagline: Digital Collection Magic with Static Web Technologies
-description: "CollectionBuilder-CONTENTdm is a template for creating digital collection exhibits on top of existing CONTENTdm repositories. This demo features materials from the Frank B. Robinson Papers documenting Psychiana, a religion popular in the 1930s and 40s."
-# Organization branding
-organization-name: "Digital Initiatives, University of Idaho Library"
-organization-link: https://www.lib.uidaho.edu/digital/
-organization-logo-banner: https://www.lib.uidaho.edu/media/digital/justdi_logo_sm.png
-organization-logo-nav: https://www.lib.uidaho.edu/media/digital/bannerlogo_allwhite.png
-
-# Collection settings
-# name of metadata file, be sure to also change page_gen data setting!
-metadata: demo_moscon
-# page gen settings
-# "data" value must be the name of the metadata file
-page_gen:
-  - data: 'demo_moscon'
-    template: 'items'
-    name: 'objectid'
-    dir: 'items'
-    extension: 'html'
-    filter: 'objectid'
-
-# Note: use environment variable on build command to include analytics
-# JEKYLL_ENV=production jekyll build
-# if present, used to add analytics during build
-google-analytics-id:
-
-# Robots exclude
-# set noindex to true if you do NOT want Google to index your site
-# noindex: true
-
-# add liquid profiler to id bottlenecks
-# profile: true
-
 exclude: [docs/, Rakefile, README.md, LICENSE, objects/, scripts/, Dockerfile, docker-compose*.yml]
-
-# compress CSS output
-sass:
-  style: compressed

--- a/_config.production_preview.yml
+++ b/_config.production_preview.yml
@@ -1,57 +1,8 @@
-# CollectionBuilder
-# Jekyll Digital Collection Generator
 
-# URL variables
 # site domain
 url: http://0.0.0.0:4000
-# location on the domain
-# e.g. /digital/hjccc
-baseurl: /demo/moscon
 
-# url to objects folder
+# url to production objects store
 digital-objects: https://lchs.sfo2.cdn.digitaloceanspaces.com
 
-# location of code
-source-code: https://github.com/CollectionBuilder
-
-# Site settings
-title: Collection Builder CDM Skin
-# header and head metadata
-tagline: Digital Collection Magic with Static Web Technologies
-description: "CollectionBuilder-CONTENTdm is a template for creating digital collection exhibits on top of existing CONTENTdm repositories. This demo features materials from the Frank B. Robinson Papers documenting Psychiana, a religion popular in the 1930s and 40s."
-# Organization branding
-organization-name: "Digital Initiatives, University of Idaho Library"
-organization-link: https://www.lib.uidaho.edu/digital/
-organization-logo-banner: https://www.lib.uidaho.edu/media/digital/justdi_logo_sm.png
-organization-logo-nav: https://www.lib.uidaho.edu/media/digital/bannerlogo_allwhite.png
-
-# Collection settings
-# name of metadata file, be sure to also change page_gen data setting!
-metadata: demo_moscon
-# page gen settings
-# "data" value must be the name of the metadata file
-page_gen:
-  - data: 'demo_moscon'
-    template: 'items'
-    name: 'objectid'
-    dir: 'items'
-    extension: 'html'
-    filter: 'objectid'
-
-# Note: use environment variable on build command to include analytics
-# JEKYLL_ENV=production jekyll build
-# if present, used to add analytics during build
-google-analytics-id:
-
-# Robots exclude
-# set noindex to true if you do NOT want Google to index your site
-# noindex: true
-
-# add liquid profiler to id bottlenecks
-# profile: true
-
 exclude: [docs/, Rakefile, README.md, LICENSE, objects/, scripts/, Dockerfile, docker-compose*.yml]
-
-# compress CSS output
-sass:
-  style: compressed

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 
 # URL variables
 # site domain
-url: http://0.0.0.0:4000
+url:
 # location on the domain
 # e.g. /digital/hjccc
 baseurl: /demo/moscon
@@ -50,7 +50,7 @@ google-analytics-id:
 # add liquid profiler to id bottlenecks
 # profile: true
 
-exclude: [docs/, Rakefile, README.md, LICENSE, objects/, scripts/, Dockerfile, docker-compose*.yml]
+exclude: [docs/, Rakefile, README.md, LICENSE, scripts/, Dockerfile, docker-compose*.yml]
 
 # compress CSS output
 sass:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -7,4 +7,4 @@ services:
       service: collectionbuilder
     environment:
       JEKYLL_ENV: production
-    command: ["build", "--config=_config.production.yml"]
+    command: ["build", "--config=_config.yml,_config.production.yml"]

--- a/docker-compose.production_preview.yml
+++ b/docker-compose.production_preview.yml
@@ -7,4 +7,4 @@ services:
       service: collectionbuilder
     environment:
       JEKYLL_ENV: production
-    command: ["s", "-H", "0.0.0.0", "--config=_config.production_preview.yml"]
+    command: ["s", "-H", "0.0.0.0", "-P", "4000", "--config=_config.yml,_config.production_preview.yml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,16 @@ version: '2.4'
 services:
   collectionbuilder:
     build: .
+    env_file: .env
     environment:
       JEKYLL_ENV: development
-    env_file: .env
     volumes:
       - .:/app
     ports:
       - 4000:4000
     network_mode: host
+    command: ["s", "-H", "0.0.0.0", "-P", "4001", "--config=_config.yml"]
+
   #   links:
   #     - elasticsearch
   # elasticsearch:


### PR DESCRIPTION
This PR reduces `_config.production_preview.yml` and `_config.production.yml` to only those values (i.e. `url`, `digital-objects`, `exclude`) that are different from those in `_config.yml` and modifies the corresponding `docker-compose.*production.yml` files to specify multiple config files.