### PR TITLE
Add Docker Secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Gemfile.lock
 
 # Ignore the collection objects
 objects/
+
+# Ignore the AWS credentials directory
+.aws

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ If you don't already have Docker and Docker Compose installed:
 
 2. If using Linux, also [install Docker Compose](https://docs.docker.com/compose/install/) (_Compose is included in Docker Desktop for Mac and Windows_)
 
+#### Configure your Digital Ocean Space / AWS Credentials
+
+To make your Digital Ocean Space / AWS credentials available within the container, create a directory in this repository's root named `.aws` and place the `credentials` file described here: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html#aws-ruby-sdk-credentials-shared within it.
+
+[This line in `docker-compose.yml`](https://github.com/CollectionBuilder/collectionbuilder-sa_draft/blob/docker/docker-compose.yml#L7) instructs Compose to make this local `.aws` directory available within the container as `/home/ubuntu/.aws`, which is where the Ruby AWS SDK expects it to be.
 
 #### Get a `bash` Shell Within a Docker Container
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   collectionbuilder:
     build: .
     volumes:
+      - .aws:/home/ubuntu/.aws
       - .:/home/ubuntu/collectionbuilder
     ports:
       - 4000:4000


### PR DESCRIPTION
FYI, @evanwill 

This PR:
- Mounts the local `<repository>/.aws` directory within the container as `/home/ubuntu/.aws`
- Adds `.aws` to `.gitignore`
- Adds a section to the README describing how to create the `.aws` directory and `credentials` file