### PR TITLE
Add Elasticsearch user credentials support to Rakefile tasks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,8 @@ digital-objects: /demo/moscon/objects
 source-code: https://github.com/CollectionBuilder
 
 # Elasticsearch cluster host
-elasticsearch-protocol: https
-elasticsearch-host: cb-elasticsearch.derekenos.com
+elasticsearch-protocol: http
+elasticsearch-host: 0.0.0.0
 elasticsearch-port: 9200
 elasticsearch-index: moscon_programs_collection
 

--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,8 @@ digital-objects: /demo/moscon/objects
 source-code: https://github.com/CollectionBuilder
 
 # Elasticsearch cluster host
-elasticsearch-protocol: http
-elasticsearch-host: 0.0.0.0
+elasticsearch-protocol: https
+elasticsearch-host: cb-elasticsearch.derekenos.com
 elasticsearch-port: 9200
 elasticsearch-index: moscon_programs_collection
 


### PR DESCRIPTION
This PR adds an optional `es_user` argument to the following `Rakefile tasks:
- `create_es_index`
- `load_es_bulk_data`
- `delete_es_index`

This is necessary to allow the user to administer a security-enabled Elasticsearch instance (e.g. when served publicly via a Digital Ocean Droplet).